### PR TITLE
fix bugs issues

### DIFF
--- a/includes/irc/Channel.hpp
+++ b/includes/irc/Channel.hpp
@@ -81,6 +81,7 @@ class Channel
 		void promoteOperatorByUser(ClientUser &user);
 		void promoteOperatorByNickname(std::string nickname);
 		void demoteOperatorByNickname(std::string nickname);
+		void transferOperatorToNextUser();
 
 		// Checks
 		bool checkTopicRestricted() const;

--- a/srcs/irc/MessageHandler.cpp
+++ b/srcs/irc/MessageHandler.cpp
@@ -374,22 +374,28 @@ void MessageHandler::joinCommandHandler(CommandMessage &message)
 				if (channel.checkInviteToChannelOnly() && !channel.checkInvitedByUser(sender))
 				{
 					sender.userBroadcast(rpl_msg::errInviteOnlyChannel(sender, channel.getChannelName()));
+					continue;
 				}
 				else if (channel.checkPasswordProtection()
 				          && !channel.checkPassword(*passes))
 				{
 					sender.userBroadcast(rpl_msg::errBadChannelKey(sender, channel.getChannelName()));
+					continue;
 				}
 				else if (channel.checkRestrictionPoint())
 				{
 					sender.userBroadcast(rpl_msg::errChanneListFull(sender, channel.getChannelName()));
+					continue;
 				}
 				else
 				{
 					context.joinUserToChannel(sender, *chans);
 					channel.revokeInvite(sender.getNickname());
 					channel.broadcast(rpl_msg::joinChannel(sender, channel));
-					sender.userBroadcast(rpl_msg::topic(message, channel));
+					if (!channel.getTopicMessage().empty())
+					{
+						sender.userBroadcast(rpl_msg::topic(message, channel));
+					}
 					sender.userBroadcast(rpl_msg::nameReply(sender, channel));
 					sender.userBroadcast(rpl_msg::endOfNames(sender, channel.getChannelName()));
 				}

--- a/srcs/irc/ModeHandler.cpp
+++ b/srcs/irc/ModeHandler.cpp
@@ -207,6 +207,7 @@ void ModeHandler::inviteChannelEnableHandler()
 	if (!targetChannel->checkInviteToChannelOnly())
 	{
 		targetChannel->setInviteOnly(true);
+		targetChannel->addModeFlags("i");
 		targetChannel->clearInvites();
 		targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 		                            "+i"));
@@ -219,6 +220,7 @@ void ModeHandler::inviteChannelDisableHandler()
 	if (targetChannel->checkInviteToChannelOnly())
 	{
 		targetChannel->setInviteOnly(false);
+		targetChannel->removeModeFlags("i");
 		targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 		                            "-i"));
 	}
@@ -230,6 +232,7 @@ void ModeHandler::topicChannelEnableHandler()
 	if (!targetChannel->checkTopicRestricted())
 	{
 		targetChannel->setTopicLock(true);
+		targetChannel->addModeFlags("t");
 		targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 		                            "+t"));
 	}
@@ -241,6 +244,7 @@ void ModeHandler::topicChannelDisableHandler()
 	if (targetChannel->checkTopicRestricted())
 	{
 		targetChannel->setTopicLock(false);
+		targetChannel->removeModeFlags("t");
 		targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 		                            "-t"));
 	}
@@ -267,6 +271,7 @@ void ModeHandler::keyChannelEnableHandler()
 		return;
 	}
 	targetChannel->setPassword(argument);
+	targetChannel->addModeFlags("k");
 	targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 	                            "+k " + argument));
 	return;
@@ -277,6 +282,7 @@ void ModeHandler::keyChannelDisableHandler()
 	if (targetChannel->checkPasswordProtection())
 	{
 		targetChannel->removePassword();
+		targetChannel->removeModeFlags("k");
 		targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 		                            "-k"));
 	}
@@ -364,6 +370,7 @@ void ModeHandler::limitChannelUserEnableHandler()
 				return;
 			}
 			targetChannel->setUserLimit(limit);
+			targetChannel->addModeFlags("l");
 			targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 			                            "+l " + argument));
 		}
@@ -380,6 +387,7 @@ void ModeHandler::limitChannelUserDisableHandler()
 	if (targetChannel->checkUserRestriction())
 	{
 		targetChannel->removeUserRestriction();
+		targetChannel->removeModeFlags("l");
 		targetChannel->broadcast(rpl_msg::modeChannel(sender, *targetChannel,
 		                            "-l"));
 	}


### PR DESCRIPTION
#### Fix the following issues:
Topic is not working 
modes are not working
+i should make the channel invite only, the user that is not on the channel cannot join without the use of the invite command
+o should make the user also an channel operator.
When the creator of the channel, which is assigned as operator, leaves, your channel is left without operator. You need to make the code pass the operator status to the first user on the list after the only operator leaves the channel.